### PR TITLE
Fix blinking Innovotech animation and update form

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ body {
     position: relative;
     color: transparent;
     -webkit-text-stroke: 1px var(--primary-color);
-    animation: preloader-fade-out-stroke 0.5s forwards 2.5s, move-to-header 0.8s forwards 2.8s;
+    animation: move-to-header 0.8s forwards 2.8s;
 }
 
 #preloader .logo::before {
@@ -685,8 +685,8 @@ section {
     transition: opacity 0.6s ease-out, transform 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 
-.footer-contact form input:nth-child(odd) { transform: translateX(-100px); }
-.footer-contact form input:nth-child(even) { transform: translateX(100px); }
+.footer-contact form input:nth-child(odd) { transform: translate(-100px, -50px); }
+.footer-contact form input:nth-child(even) { transform: translate(100px, -50px); }
 .footer-contact form textarea { transform: translateY(80px); }
 .footer-contact form button { transform: scale(0.5); }
 
@@ -726,7 +726,7 @@ footer {
 
 form {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
     gap: 15px;
     margin-top: 30px;
     text-align: left;


### PR DESCRIPTION
- Removed the `preloader-fade-out-stroke` animation to prevent the "Innovotech" text from blinking during the initial load.
- Changed the "Get in Touch" form to a single-column layout by updating the `grid-template-columns` CSS property.
- Modified the form's entry animation to have fields fall in from different sides, and refactored the CSS for conciseness.